### PR TITLE
Writer ordering and interface

### DIFF
--- a/test.config
+++ b/test.config
@@ -1,0 +1,6 @@
+f|./test/|2.txt
+f|./test/|3.txt
+sd|./test/|subfolder
+f|./test/subfolder|4.txt
+ed|./test/|subfolder
+f|./test/|1.txt

--- a/writer.go
+++ b/writer.go
@@ -183,6 +183,8 @@ func (z *zarManager) WalkDir(dir string, foldername string, root bool) {
 		log.Fatalf("walk dir unknown err when processing dir %v", dir)
 	}
 
+	var dirs []string
+
 	// Process each file in the directory
 	for _, file := range files {
 		name := file.Name()
@@ -190,9 +192,14 @@ func (z *zarManager) WalkDir(dir string, foldername string, root bool) {
 			fmt.Printf("including file: %v\n", name)
 			z.IncludeFile(name, dir)
 		} else {
-			// Depth first search recursively on each directory
-			z.WalkDir(path.Join(dir, name), name, false)
+			dirs = append(dirs, name)
 		}
+	}
+
+	// Recursively search each directory (DFS)
+	// After file processing to improve spatial locatlity for files
+	for _, subDir := range dirs {
+		z.WalkDir(path.Join(dir, subDir), subDir, false)
 	}
 
 	// root dir not marked as directory

--- a/writer.go
+++ b/writer.go
@@ -16,50 +16,62 @@ import (
 	"syscall"
 )
 
+const (
+	pageBoundary = 4096	// The boundary that needs to be upheld for page alignment
+)
+
+// TODO 
+// Add new struct for walking directories
+// Can have one that will do a breadth first search based on current implementation
+// Can have another that will walk based on a yaml file uploaded
+// TODO
+
+// fileWriter struct writes to a file
 type fileWriter struct {
-	zarw *bufio.Writer
+	// zarw is used as the writer to the file f
+	zarw *bufio.Write
+
+	// Count is the cumulative bytes written to the file f 
 	count int64
+
+	// f is the file object that the writer will write to
 	f *os.File
 }
 
-type fileMetadata struct {
-	Begin int64
-	End int64
-	Name string
-}
 
-type zarManager struct {
- pagealign bool
- writer fileWriter
- metadata []fileMetadata
-}
-
+// Initializes a writer by creating the image file and attaching a writer to it\
+//
+// Parameter (fn): Name of image file
 func (w *fileWriter) Init(fn string) error {
 	if w.count != 0 {
-		err := "unkown error, writer counter is not 0 when initializing"
+		err := "unknown error, writer counter is not 0 when initializing"
 		log.Fatalf(err)
 		return errors.New(err)
 	}
+
+	// Create image file
 	f, err := os.Create(fn)
 	if err != nil {
 		log.Fatalf("can't open zar output file %v, err: %v", fn, err)
 		return err
 	}
+
+	// Initiaize the buffer writer
 	w.f = f
 	w.zarw = bufio.NewWriter(f)
 	return nil
 }
+
 // NOTE: in the new version fileWriter.Writer return the "real" end
-func (w *fileWriter) Write(data []byte, pagealign bool) (int64, error) {
+func (w *fileWriter) Write(data []byte, pageAlign bool) (int64, error) {
 	n, err := w.zarw.Write(data)
 	if err != nil {
 		return int64(n), err
 	}
 
 	n2 := 0
-	if pagealign {
-		const align = 4096
-		pad := (align - n % align) % 4096
+	if pageAlign {
+		pad := (align - n % align) % pageBoundary
 		fmt.Printf("current write size: %v, padding size: %v\n", n, pad)
 		if pad > 0 {
 			s := make([]byte, pad)
@@ -74,130 +86,220 @@ func (w *fileWriter) Write(data []byte, pagealign bool) (int64, error) {
 	return realEnd, err
 }
 
+// WriteInt64 writes a int64 to the fileWriter
+//
+// parameter (v)	: the value to be written
 func (w *fileWriter) WriteInt64(v int64) (int64, error) {
 	buf := make([]byte, binary.MaxVarintLen64)
 	binary.PutVarint(buf, v)
 	n, err := w.Write(buf, false)
+
+	// Extends the file offset
 	w.count += int64(n)
 	return n, err
 }
 
+// Close closes the filewriter by flushing any buffer
 func (w *fileWriter) Close() error {
 	fmt.Println("Written Bytes: ", w.count)
 	w.zarw.Flush()
 	return w.f.Close()
 }
 
-func (z *zarManager) IncludeFile(fn string, basedir string) (int64, error) {
-	content, err := ioutil.ReadFile(path.Join(basedir, fn))
-	if err != nil {
-		log.Fatalf("can't include file %v, err: %v", fn, err)
-		return 0, nil
-	}
-	oldCounter := z.writer.count
-	real_end, err := z.writer.Write(content, z.pagealign)
-	if err != nil {
-			log.Fatalf("can't write to file")
-			return 0, err
-	}
+// zarManager is the main driver of creating the image file. It writes the data and stores metadata.
+type zarManager struct {
+	// pageAlign indicates whether files will be aligned at page boundaries
+	pageAlign bool
 
-	h := &fileMetadata{
-			Begin : oldCounter,
-			End	  : real_end,
-			Name  : fn,
-	}
-	z.metadata = append(z.metadata, *h)
-	return real_end, err
+	// The fileWriter for this zar image
+	writer fileWriter
+
+	// metadata is a list of fileMetadata structs indicating start and end of directories and files
+	metadata []fileMetadata
 }
 
-func (z *zarManager) IncludeFolderBegin(name string) {
-	h := &fileMetadata{
-			Begin : -1,
-			End	  : -1,
-			Name  : name,
-	}
-	z.metadata = append(z.metadata, *h)
+// fileMetadata holds information for the location of a file in the image file
+type fileMetadata struct {
+	// Begin indicates the beginning of a file (pointer) in the file
+	Begin int64
+
+	// End indicates the ending of a file (pointer) in the file
+	End int64
+
+	// Name indicates the name of a specific file in the file
+	Name string
 }
 
-func (z *zarManager) IncludeFolderEnd() {
-	h := &fileMetadata{
-			Begin : -1,
-			End	  : -1,
-			Name  : "..",
-	}
-	z.metadata = append(z.metadata, *h)
-}
-
-func (z *zarManager) WriteHeader() error {
-	headerLoc := z.writer.count
-	mEnc := gob.NewEncoder(z.writer.zarw)
-	fmt.Println("current metadata:", z.metadata)
-	//**test**
-	var test bytes.Buffer
-	mEncTest := gob.NewEncoder(&test)
-	mEncTest.Encode(z.metadata)
-	fmt.Println("test gob encode result:", test)
-	//**test**
-	mEnc.Encode(z.metadata)
-	fmt.Printf("header location: %v bytes\n", headerLoc)
-	z.writer.WriteInt64(int64(headerLoc))
-	if err := z.writer.Close(); err != nil {
-		log.Fatalf("can't close zar file: %v", err)
-	}
-	return nil
-}
-
-func writeImage(dir string, output string, pagealign bool) {
-	z := &zarManager{pagealign:pagealign}
-	z.writer.Init(output)
-	walkDir(dir, dir, z, true)
-	z.WriteHeader()
-}
-
-func walkDir(dir string, foldername string, z *zarManager, root bool) {
+// WalkDir recursively traverses each directory below the root director and processes files
+// by creating metadata.
+//
+// Parameter (dir) 		: name of path relative to root dir
+// parameter (foldername) 	: name of current folder
+// parameter (root)		: whether or not dir is the root dir
+// TODO: Change this to breadth first search to see difference (Change to an interface to implement diff types)
+func (z *zarManager) WalkDir(dir string, foldername string, root bool) {
+	// root dir not marked as directory
 	if !root {
 		fmt.Printf("including folder: %v, name: %v\n", dir, foldername)
 		z.IncludeFolderBegin(foldername)
 	}
+
+	// Retrieve all files in current directory
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		log.Fatalf("walk dir unknown err when processing dir %v", dir)
 	}
+
+	// Process each file in the directory
 	for _, file := range files {
 		name := file.Name()
 		if !file.IsDir() {
 			fmt.Printf("including file: %v\n", name)
 			z.IncludeFile(name, dir)
 		} else {
-			walkDir(path.Join(dir, name), name, z, false)
+			// Depth first search recursively on each directory
+			z.WalkDir(path.Join(dir, name), name, false)
 		}
 	}
+
+	// root dir not marked as directory
 	if !root {
 		z.IncludeFolderEnd()
 	}
 }
 
+// TODO: Change to interface for metadata to have diff types of metadata
+// IncludeFolderBegin initializes metadata for the beginning of a file
+//
+// parameter (name)	: name of the file beginning
+func (z *zarManager) IncludeFolderBegin(name string) {
+	h := &fileMetadata{
+			Begin	: -1,
+			End	: -1,
+			Name	: name,
+	}
+
+	// Add to the image's metadata at end
+	z.metadata = append(z.metadata, *h)
+}
+
+// IncludeFolderEnd initializes metadata for the end of a file
+func (z *zarManager) IncludeFolderEnd() {
+	h := &fileMetadata{
+			Begin	: -1,
+			End	: -1,
+			Name	: "..",
+	}
+
+	// Add to the image's metadata at end
+	z.metadata = append(z.metadata, *h)
+}
+
+// IncludeFile reads the given file, adds it to the file, and creates the metadata.
+//
+// parameter (fn)	: name of the file to be read
+// paramter (basedir)	: name of the current directory relative to root
+// return		: new offset into the image file
+func (z *zarManager) IncludeFile(fn string, basedir string) (int64, error) {
+	content, err := ioutil.ReadFile(path.Join(basedir, fn))
+	if err != nil {
+		log.Fatalf("can't include file %v, err: %v", fn, err)
+		return 0, nil
+	}
+
+	// Retrieve the current offset into the file and write the file contents
+	oldCounter := z.writer.count
+	real_end, err := z.writer.Write(content, z.pageAlign)
+	if err != nil {
+			log.Fatalf("can't write to file")
+			return 0, err
+	}
+
+	// Create the file metadata
+	h := &fileMetadata{
+			Begin	: oldCounter,
+			End	: real_end,
+			Name	: fn,
+	}
+	z.metadata = append(z.metadata, *h)
+
+	return real_end, err
+}
+
+// TODO: Is gob the best choice here?
+// WriterHeader writes the metadata for the imagefile to the end of the image file.
+// The location of the beginning of the header is written at the very end as an int64
+func (z *zarManager) WriteHeader() error {
+	headerLoc := z.writer.count	// Offset for metadata in image file
+	fmt.Printf("header location: %v bytes\n", headerLoc)
+
+	mEnc := gob.NewEncoder(z.writer.zarw)
+
+	fmt.Println("current metadata:", z.metadata)
+	mEnc.Encode(z.metadata)
+
+	// Write location of metadata to end of file
+	z.writer.WriteInt64(int64(headerLoc))
+
+	if err := z.writer.Close(); err != nil {
+		log.Fatalf("can't close zar file: %v", err)
+	}
+	return nil
+}
+
+// writeImage acts as the "main" method by creating and initializing the zarManager, 
+// beginning the recursive walk of the directories, and writing the metadata header
+//
+// parameter (dir)	: the root dir name
+// parameter (output)	: the name of the image file
+// parameter (pageAlign): whether the files in the image will be page aligned
+func writeImage(dir string, output string, pageAlign bool) {
+	z := &zarManager{pageAlign:pageAlign}
+	z.writer.Init(output)
+
+	// Begin recursive walking of directories
+	z.WalkDir(dir, dir, true)
+
+	// Write the metadata to end of file
+	z.WriteHeader()
+}
+
+// TODO: Break up into smaller methods
+// readImage will open the given file, extract the metadata, and print out
+// the structure and/or data for each file and directory in the image file.
+//
+// parameter (img)	: name of the image file to be read
+// parameter (detail)	: whether to print extra information (file data)
 func readImage(img string, detail bool) error {
 	f, err := os.Open(img)
 	if err != nil {
 		log.Fatalf("can't open image file %v, err: %v", img, err)
 		return err
 	}
+
 	fi, err := f.Stat()
 	if err != nil {
 		log.Fatalf("can't stat image file %v, err: %v", img, err)
 	}
+
 	length := int(fi.Size()) // MMAP limitation. May not support large file in32 bit system
 	fmt.Printf("this image file has %v bytes\n", length)
+
+	// mmap image into address space
 	mmap, err := syscall.Mmap(int(f.Fd()), 0, length, syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		log.Fatalf("can't mmap the image file, err: %v", err)
 	}
+
 	if detail {
 		fmt.Println("MMAP data:", mmap)
 	}
+
+	// header location is specifed by int64 at last 10 bits (bytes?)
 	headerLoc := mmap[length - 10 : length]
 	fmt.Println("header data:", headerLoc)
+
+	// Setup reader for header data
 	headerReader := bytes.NewReader(headerLoc)
 	n, err := binary.ReadVarint(headerReader)
 	if err != nil {
@@ -205,22 +307,28 @@ func readImage(img string, detail bool) error {
 	}
 	fmt.Printf("headerLoc: %v bytes\n", n)
 
+	var metadata []fileMetadata
 	header := mmap[int(n) : length - 10]
 	fmt.Println("metadata data:", header)
+
+	// Decode the metadata in the header
 	metadataReader := bytes.NewReader(header)
-	var metadata []fileMetadata
 	dec := gob.NewDecoder(metadataReader)
 	errDec := dec.Decode(&metadata)
 	if errDec != nil {
 		  log.Fatalf("can't decode metadata data, err: %v", errDec)
 			return err
 	}
-	fmt.Println(metadata)
+	fmt.Println("metadata data decoded:", metadata)
+
+	// Print the structure (and data) of the image file
 	for _, v := range metadata {
 		if v.Begin == -1 {
 			fmt.Printf("enter folder: %v\n", v.Name)
 		} else {
 			var fileString string
+
+			// the detail flag will print out file data, too
 			if detail {
 				fileBytes := mmap[v.Begin : v.End]
 				fileString = string(fileBytes)
@@ -234,9 +342,12 @@ func readImage(img string, detail bool) error {
 }
 
 func main() {
-
+	// TODO: Add config file for version number
 	fmt.Println("zar image generator version 1")
-	dirPtr := flag.String("dir", "./", "select the dir to generate image")
+
+	// TODO: Add flag for info logging
+	// Handle flags
+	dirPtr := flag.String("dir", "./", "select the root dir to generate image")
 	imgPtr := flag.String("img", "test.img", "select the image to read")
 	outputPtr := flag.String("o", "test.img", "output img name")
 	writeModePtr := flag.Bool("w", false, "generate image mode")
@@ -246,7 +357,7 @@ func main() {
 	flag.Parse()
 
 	if *writeModePtr {
-		fmt.Printf("dir selected: %v\n", *dirPtr)
+		fmt.Printf("root dir: %v\n", *dirPtr)
 		writeImage(*dirPtr, *outputPtr, *pageAlignPtr)
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -29,7 +29,7 @@ const (
 // fileWriter struct writes to a file
 type fileWriter struct {
 	// zarw is used as the writer to the file f
-	zarw *bufio.Write
+	zarw *bufio.Writer
 
 	// Count is the cumulative bytes written to the file f 
 	count int64
@@ -78,7 +78,7 @@ func (w *fileWriter) Write(data []byte, pageAlign bool) (int64, error) {
 	// Adds padding if last page is not page aligned
 	n2 := 0
 	if pageAlign {
-		pad := (align - n % align) % pageBoundary
+		pad := (pageBoundary - n % pageBoundary) % pageBoundary
 		fmt.Printf("current write size: %v, padding size: %v\n", n, pad)
 		if pad > 0 {
 			s := make([]byte, pad)


### PR DESCRIPTION
1) Added comprehensive commenting to improve read quality for people not developing directly. 
2) Changed zarManager to be an implementation of a Manager interface for future implementations of the creation of an image file. 
3) Defered directories to be traversed by zarManager until after the files have been laid out sequentially in the image file. May increase performance due to locality.