### PR TITLE
add modification time field in imgfs metadata

### DIFF
--- a/src/manager/cmanager.go
+++ b/src/manager/cmanager.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 )
 
 // CManager ("configmanager") is a struct for writing image files from a configuration file
-// The configuration file will specify which files to read (relative to root dir) 
+// The configuration file will specify which files to read (relative to root dir)
 // and in what order to put them in img file.
 type CManager struct {
         // Inherits manager's methods
@@ -47,9 +48,9 @@ func (c *CManager) WalkDir(dir string, foldername string, root bool) {
 
                 switch action {
                 case "f":
-                        c.IncludeFile(name, path)
+                        c.IncludeFile(name, path, time.Time{})
                 case "sd":
-                        c.IncludeFolderBegin(name)
+                        c.IncludeFolderBegin(name, time.Time{})
                 case "ed":
                         c.IncludeFolderEnd()
                 default:
@@ -57,4 +58,3 @@ func (c *CManager) WalkDir(dir string, foldername string, root bool) {
                 }
         }
 }
-

--- a/src/manager/cmanager.go
+++ b/src/manager/cmanager.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
 )
 
 // CManager ("configmanager") is a struct for writing image files from a configuration file
@@ -48,9 +47,10 @@ func (c *CManager) WalkDir(dir string, foldername string, root bool) {
 
                 switch action {
                 case "f":
-                        c.IncludeFile(name, path, time.Time{})
+                        c.IncludeFile(name, path, 0)
+                        // TODO: change 0 to valid timestamp
                 case "sd":
-                        c.IncludeFolderBegin(name, time.Time{})
+                        c.IncludeFolderBegin(name, 0)
                 case "ed":
                         c.IncludeFolderEnd()
                 default:

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path"
+  "time"
 
 	"fileio/writer"
 )
@@ -32,12 +33,12 @@ type Manager interface {
         // Parameter (dir)              : name of path relative to root dir
         // parameter (foldername)       : name of current folder
         // parameter (root)             : whether or not dir is the root dir
-        WalkDir(dir string, foldername string, root bool)
+        WalkDir(dir string, foldername string, mod_time time.Time, root bool)
 
         // IncludeFolderBegin initializes Metadata for the beginning of a file
         //
         // parameter (name)     : name of the file beginning
-        IncludeFolderBegin(name string)
+        IncludeFolderBegin(name string, mod_time time.Time)
 
         // IncludeFolderEnd initializes Metadata for the end of a file
         IncludeFolderEnd()
@@ -47,7 +48,7 @@ type Manager interface {
         // parameter (fn)       : name of the file to be read
         // paramter (basedir)   : name of the current directory relative to root
         // return               : new offset into the image file
-        IncludeFile(fn string, basedir string) (int64, error)
+        IncludeFile(fn string, basedir string, mod_time time.Time) (int64, error)
 
         // WriterHeader writes the Metadata for the imagefile to the end of the image file.
         // The location of the beginning of the header is written at the very end as an int64
@@ -68,6 +69,9 @@ type FileMetadata struct {
         // If the file is a symlink, this entry is used for link info
         Link string
 
+				// File modification time
+        ModTime time.Time
+
         // Type indicated the type of a specific file (dir, symlink or regular file)
         Type fileType
 }
@@ -84,12 +88,17 @@ type ZarManager struct {
         Metadata []FileMetadata
 }
 
+type DirInfo struct {
+        Name string
+				ModTime time.Time
+}
+
 // WalkDir implemented Manager.WalkDir
-func (z *ZarManager) WalkDir(dir string, foldername string, root bool) {
+func (z *ZarManager) WalkDir(dir string, foldername string, mod_time time.Time, root bool) {
         // root dir not marked as directory
         if !root {
                 fmt.Printf("including folder: %v, name: %v\n", dir, foldername)
-                z.IncludeFolderBegin(foldername)
+                z.IncludeFolderBegin(foldername, mod_time)
         }
 
         // Retrieve all files in current directory
@@ -98,13 +107,14 @@ func (z *ZarManager) WalkDir(dir string, foldername string, root bool) {
                 log.Fatalf("walk dir unknown err when processing dir %v", dir)
         }
 
-        var dirs []string
+        var dirs []*DirInfo
 
         // Process each file in the directory
         for _, file := range files {
                 name := file.Name()
                 symlink := file.Mode() & os.ModeSymlink != 0
                 file_path := path.Join(dir, name)
+                mod_time := file.ModTime()
 
                 if symlink {
                         // Symbolic link is an indirection, thus read and include
@@ -114,13 +124,13 @@ func (z *ZarManager) WalkDir(dir string, foldername string, root bool) {
                                 log.Fatalf("error. Can't read symlink file. %v", real_dest)
                         }
                         // TODO: Can we replace with file redirecting to here? Could eliminate symbolic links
-                        z.IncludeSymlink(name, real_dest)
+                        z.IncludeSymlink(name, real_dest, mod_time)
                 } else {
                         if !file.IsDir() {
                                 fmt.Printf("including file: %v\n", name)
-                                z.IncludeFile(name, dir)
+                                z.IncludeFile(name, dir, mod_time)
                                 } else {
-                                                dirs = append(dirs, name)
+                                        dirs = append(dirs, &DirInfo{name, mod_time})
                         }
                 }
         }
@@ -128,7 +138,7 @@ func (z *ZarManager) WalkDir(dir string, foldername string, root bool) {
         // Recursively search each directory (DFS)
         // After file processing to improve spatial locatlity for files
         for _, subDir := range dirs {
-                z.WalkDir(path.Join(dir, subDir), subDir, false)
+                z.WalkDir(path.Join(dir, subDir.Name), subDir.Name, subDir.ModTime, false)
         }
 
         // root dir not marked as directory
@@ -139,12 +149,13 @@ func (z *ZarManager) WalkDir(dir string, foldername string, root bool) {
 
 // TODO: Change to interface for Metadata to have diff types of Metadata
 // IncludeFolderBegin implements Manager.IncludeFolderBegin
-func (z *ZarManager) IncludeFolderBegin(name string) {
+func (z *ZarManager) IncludeFolderBegin(name string, mod_time time.Time) {
         h := &FileMetadata{
                         Begin   : -1,
                         End     : -1,
                         Name    : name,
                         Type    : Directory,
+												ModTime	: mod_time,
         }
 
         // Add to the image's Metadata at end
@@ -170,19 +181,22 @@ func (z *ZarManager) IncludeFolderEnd() {
 //
 // parameter (name)     : name of file
 // parameter (link)     : the actual path to the desired file
-func (z *ZarManager) IncludeSymlink(name string, link string) {
+// parameter (mod_time) : the modification time fo the file
+
+func (z *ZarManager) IncludeSymlink(name string, link string, mod_time time.Time) {
         h := &FileMetadata{
                         Begin   : -1,
                         End     : -1,
                         Name    : name,
                         Link    : link,
                         Type    : Symlink,
+												ModTime : mod_time,
         }
         z.Metadata = append(z.Metadata, *h)
 }
 
 // IncludeFile implements Manager.IncludeFile
-func (z *ZarManager) IncludeFile(fn string, basedir string) (int64, error) {
+func (z *ZarManager) IncludeFile(fn string, basedir string, mod_time time.Time) (int64, error) {
         content, err := ioutil.ReadFile(path.Join(basedir, fn))
         if err != nil {
                 log.Fatalf("can't include file %v, err: %v", fn, err)
@@ -203,6 +217,7 @@ func (z *ZarManager) IncludeFile(fn string, basedir string) (int64, error) {
                         End     : real_end,
                         Name    : fn,
                         Type    : RegularFile,
+												ModTime : mod_time,
         }
         z.Metadata = append(z.Metadata, *h)
 

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -18,7 +18,7 @@ type fileType int
 
 const (
 	// Represent the possible file types for files
-	RegularFile fileType = iota
+    RegularFile fileType = iota
     Directory
     Symlink
 )
@@ -89,7 +89,7 @@ type ZarManager struct {
 
 type DirInfo struct {
         Name string
-		ModTime int64 
+        ModTime int64 
 }
 
 // WalkDir implemented Manager.WalkDir
@@ -128,8 +128,8 @@ func (z *ZarManager) WalkDir(dir string, foldername string, mod_time int64, root
                         if !file.IsDir() {
                                 fmt.Printf("including file: %v\n", name)
                                 z.IncludeFile(name, dir, mod_time)
-                                } else {
-                                        dirs = append(dirs, &DirInfo{name, mod_time})
+                        } else {
+                                dirs = append(dirs, &DirInfo{name, mod_time})
                         }
                 }
         }
@@ -150,11 +150,11 @@ func (z *ZarManager) WalkDir(dir string, foldername string, mod_time int64, root
 // IncludeFolderBegin implements Manager.IncludeFolderBegin
 func (z *ZarManager) IncludeFolderBegin(name string, mod_time int64) {
         h := &FileMetadata{
-                        Begin   : -1,
-                        End     : -1,
-                        Name    : name,
-                        Type    : Directory,
-						ModTime	: mod_time,
+                    Begin   : -1,
+                    End     : -1,
+                    Name    : name,
+                    Type    : Directory,
+                    ModTime	: mod_time,
         }
 
         // Add to the image's Metadata at end
@@ -189,7 +189,7 @@ func (z *ZarManager) IncludeSymlink(name string, link string, mod_time int64) {
                         Name    : name,
                         Link    : link,
                         Type    : Symlink,
-						ModTime : mod_time,
+                        ModTime : mod_time,
         }
         z.Metadata = append(z.Metadata, *h)
 }
@@ -216,7 +216,7 @@ func (z *ZarManager) IncludeFile(fn string, basedir string, mod_time int64) (int
                         End     : real_end,
                         Name    : fn,
                         Type    : RegularFile,
-						ModTime : mod_time,
+                        ModTime : mod_time,
         }
         z.Metadata = append(z.Metadata, *h)
 

--- a/src/zar/main.go
+++ b/src/zar/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"syscall"
+	"time"
 
 	// TODO: Change paths to be remotely imported from github
 	"manager"
@@ -54,7 +55,7 @@ func writeImage(dir string, output string, pageAlign bool, config bool, configPa
 		z.Writer.Init(output)
 
 		// Begin recursive walking of directories
-		z.WalkDir(dir, dir, true)
+		z.WalkDir(dir, dir, time.Time{}, true)
 
 		// Write the metadata to end of file
 		z.WriteHeader()

--- a/src/zar/main.go
+++ b/src/zar/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"syscall"
-	"time"
 
 	// TODO: Change paths to be remotely imported from github
 	"manager"
@@ -55,7 +54,7 @@ func writeImage(dir string, output string, pageAlign bool, config bool, configPa
 		z.Writer.Init(output)
 
 		// Begin recursive walking of directories
-		z.WalkDir(dir, dir, time.Time{}, true)
+		z.WalkDir(dir, dir, 0, true)
 
 		// Write the metadata to end of file
 		z.WriteHeader()


### PR DESCRIPTION
Extra field in metadata: ModTime

I have confirmed that python reject the pycache because of the timestamp problem. I have injected detection code in CPython 3.7 version and with the support of modification time it won't recompile everything this time.

Please feel free to let me know if you have any suggestions & questions.
